### PR TITLE
Add super method to onInit, onReady

### DIFF
--- a/lib/samples/impl/get_controller.dart
+++ b/lib/samples/impl/get_controller.dart
@@ -20,10 +20,14 @@ class ${_fileName.pascalCase}Controller extends GetxController {
   
 
   @override
-  void onInit() {}
+  void onInit() {
+    super.onInit();
+  }
 
   @override
-  void onReady() {}
+  void onReady() {
+    super.onReady();
+  }
 
   @override
   void onClose() {}
@@ -37,9 +41,13 @@ class ${_fileName.pascalCase}Controller extends GetxController {
   
   final count = 0.obs;
   @override
-  void onInit() {}
+  void onInit() {
+    super.onInit();
+  }
   @override
-  void onReady() {}
+  void onReady() {
+    super.onReady();
+  }
   @override
   void onClose() {}
   void increment() => count.value++;


### PR DESCRIPTION
everytime generate get controller has warning on onInit and onReady.
```
This method overrides a method annotated as '@mustCallSuper' in 'DisposableInterface', but doesn't invoke the overridden method.
```