### PR TITLE
json conversion error

### DIFF
--- a/lib/common/utils/json_serialize/sintaxe.dart
+++ b/lib/common/utils/json_serialize/sintaxe.dart
@@ -152,9 +152,7 @@ class TypeDefinition {
       return "data['$key'] = $thisKey;";
     } else if (name == 'List') {
       // class list
-      return """if ($thisKey != null) {
-      data['$key'] = $thisKey${PubspecUtils.nullSafeSupport ? '?' : ''}.map((v) => ${_buildToJsonClass('v', nullSafe: false)}).toList();
-    }""";
+      return "data['$key'] = this.$thisKey${PubspecUtils.nullSafeSupport ? '?' : ''}.map((v) => ${_buildToJsonClass('v', nullSafe: false)}).toList();";
     } else {
       // class
       return """if ($thisKey != null) {


### PR DESCRIPTION
When I use the following json:
{
  "code": 0,
  "msg": "",
  "data": [
    {
      "id": null,
      "remark": null,
      "createdBy": null,
      "createdAt": null,
      "updatedBy": null,
      "updatedAt": null,
      "delFlag": null,
      "belongCustomerId": null,
      "appCode": null,
      "agreementName": "agreementName",
      "functionCode": "functionCode",
      "richTextId": null,
      "richTextContent": "richTextContent",
      "updateBy": null
    }
  ]
}
There will be multiple "data" in the "toJson" method, and I have made modifications to meet such usage scenarios.