### PR TITLE
Add `--no-version-check` flag

### DIFF
--- a/bin/get.dart
+++ b/bin/get.dart
@@ -8,18 +8,19 @@ Future<void> main(List<String> arguments) async {
   time.start();
   final command = GetCli(arguments).findCommand();
 
-  if (arguments.contains('--debug')) {
+  try {
     if (command.validate()) {
-      await command.execute().then((value) => checkForUpdate());
+      await command.execute().then((value) {
+        if (!arguments.contains('--no-version-check')) {
+          checkForUpdate();
+        }
+      });
     }
-  } else {
-    try {
-      if (command.validate()) {
-        await command.execute().then((value) => checkForUpdate());
-      }
-    } on Exception catch (e) {
-      ExceptionHandler().handle(e);
+  } on Exception catch (e) {
+    if (arguments.contains('--debug')) {
+      rethrow;
     }
+    ExceptionHandler().handle(e);
   }
   time.stop();
   LogService.info('Time: ${time.elapsed.inMilliseconds} Milliseconds');


### PR DESCRIPTION
In many cases we don't need to perform an update check every time, so I added the `--no-version-check` flag to allow users to skip the version check.