### PR TITLE
feat: sort locale files (a-z)

### DIFF
--- a/lib/commands/impl/generate/locales/locales.dart
+++ b/lib/commands/impl/generate/locales/locales.dart
@@ -37,6 +37,8 @@ class GenerateLocalesCommand extends Command {
         .where((entry) => entry.path.endsWith('.json'))
         .toList();
 
+    files.sort((a, b) => basename(a.path).compareTo(basename(b.path)));
+
     if (files.isEmpty) {
       LogService.info(LocaleKeys.error_empty_directory.trArgs([inputPath]));
       return;


### PR DESCRIPTION
macOS and linux have the opposite order of files, and when I regenerate the locales file on another system, the content will change a lot. Now I fix it in order from a to z to make sure the generated content is consistent under different systems