### PR TITLE
[Urgent] fix generate model optional double type

### DIFF
--- a/lib/common/utils/json_serialize/sintaxe.dart
+++ b/lib/common/utils/json_serialize/sintaxe.dart
@@ -127,7 +127,10 @@ class TypeDefinition {
         fixFieldName(key, typeDef: this, privateField: privateField);
     if (isPrimitive) {
       if (name == 'List') {
-        return "$fieldKey = json['$key'].cast<$subtype>();";
+        return "$fieldKey = json['$key']?.cast<$subtype>();";
+      }
+      if (name == 'double?') {
+        return "$fieldKey = (json['$key'] as num?)?.toDouble();";
       }
       return "$fieldKey = json['$key'];";
     } else if (name == 'List' && subtype == 'DateTime') {

--- a/lib/common/utils/shell/shel.utils.dart
+++ b/lib/common/utils/shell/shel.utils.dart
@@ -17,8 +17,8 @@ class ShellUtils {
 
   static Future<void> activatedNullSafe() async {
     await pubGet();
-    await run('dart migrate --apply-changes --skip-import-check',
-        verbose: true);
+    // await run('dart migrate --apply-changes --skip-import-check',
+    //     verbose: true);
   }
 
   static Future<void> flutterCreate(


### PR DESCRIPTION
The problem is when the json value doesn't have decimal sometimes.
For Example normal value.

```json
{
    "some_value": 123.45
}
```

And then it works with before.

```dart
class Test {
    double? someValue;

    Test.fromJson(Map<String, dynamic> json) {
        someValue = json['some_value'];
    }
}
```

=======================================================

But sometimes when value doesn't have decimal like this in same attribute.

```json
{
    "some_value": 123
}
```

 It will be seen as an `int`, my solution should declare as `num?` first. then use `toDouble()`

```dart
class Test {
    double? someValue;

    Test.fromJson(Map<String, dynamic> json) {
        someValue = (json['some_value'] as num?)?.toDouble();
    }
}
```