### PR TITLE
🔥[Urgent] Fix dcli issue when `get create project`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: get_cli
-version: 1.8.2
+version: 1.8.4
 homepage: https://github.com/jonataslaw/get_cli
 description: Official CLI for GetX™ framework to build Flutter and Server
   Applications easily
@@ -11,7 +11,7 @@ dependencies:
   ansicolor: ">=2.0.1 <3.0.0"
   collection: ">=1.15.0 <2.0.0"
   dart_style: ">=2.0.1 <3.0.0"
-  dcli: ^2.3.0
+  dcli: ^4.0.1-alpha.8
   http: ">=0.13.4 <2.0.0"
   intl: ">=0.17.0 <1.0.0"
   meta: ">=1.7.0 <2.0.0"
@@ -23,8 +23,8 @@ dependencies:
   yaml: ">=3.1.0 <4.0.0"
 
 dev_dependencies:
-  lints: ^2.0.0
-  test: ^1.5.0
+  lints: ^3.0.0
+  test: ^1.25.2
 
 executables:
   get: get


### PR DESCRIPTION
Fix dcli issue when `get create project` and update dependencies

For people who are waiting for this 
you can use my repository for now
```cmd
dart pub global deactivate get_cli

dart pub global activate -s git https://github.com/knottx/get_cli.git --git-ref knottx
```