### PR TITLE
UPDATE: Update impl/get_view.dart to adhere Flutter's - use_super_parameters

### DIFF
--- a/lib/samples/impl/get_view.dart
+++ b/lib/samples/impl/get_view.dart
@@ -25,7 +25,7 @@ import 'package:get/get.dart';
 $import
 
 class $_viewName extends $_controllerName {
- const $_viewName({Key? key}) : super(key: key);
+ const $_viewName({super.key});
   @override
   Widget build(BuildContext context) {
     return Scaffold(


### PR DESCRIPTION
Adhere Flutter's - Convert 'key' to a super parameter.dart (use_super_parameters)

Initial code generation
<img width="463" alt="Screenshot 2024-04-24 at 9 28 15 PM" src="https://github.com/jonataslaw/get_cli/assets/72927125/9f571cf6-b46c-4a40-b608-23cbce2c600d">

Flutter's recommendation
<img width="505" alt="Screenshot 2024-04-24 at 9 28 25 PM" src="https://github.com/jonataslaw/get_cli/assets/72927125/e5519820-2bba-4a65-9730-04a2b0998fee">

Output
<img width="513" alt="Screenshot 2024-04-24 at 9 28 31 PM" src="https://github.com/jonataslaw/get_cli/assets/72927125/d3820d8e-981a-4f71-9218-e43694aeb57e">
