### PR TITLE
Support GetX5 🚀

### DIFF
--- a/lib/samples/impl/analysis_options.dart
+++ b/lib/samples/impl/analysis_options.dart
@@ -13,4 +13,7 @@ linter:
   rules:
     
 ''';
+
+  @override
+  String? get getX5Content => null;
 }

--- a/lib/samples/impl/arctekko/arc_main.dart
+++ b/lib/samples/impl/arctekko/arc_main.dart
@@ -28,4 +28,7 @@ class Main extends StatelessWidget {
     
   }
 }''';
+
+  @override
+  String? get getX5Content => null;
 }

--- a/lib/samples/impl/arctekko/arc_navigation.dart
+++ b/lib/samples/impl/arctekko/arc_navigation.dart
@@ -35,4 +35,7 @@ class Nav {
   static List<GetPage> routes = [
   ];
 }''';
+
+  @override
+  String? get getX5Content => null;
 }

--- a/lib/samples/impl/arctekko/arc_routes.dart
+++ b/lib/samples/impl/arctekko/arc_routes.dart
@@ -14,4 +14,7 @@ class Routes {
   }
 }
 ''';
+
+  @override
+  String? get getX5Content => null;
 }

--- a/lib/samples/impl/arctekko/arc_screen.dart
+++ b/lib/samples/impl/arctekko/arc_screen.dart
@@ -70,4 +70,7 @@ class CounterScreen extends GetView<CounterController> {
   }
 }
 ''';
+
+  @override
+  String? get getX5Content => null;
 }

--- a/lib/samples/impl/arctekko/config_example.dart
+++ b/lib/samples/impl/arctekko/config_example.dart
@@ -39,4 +39,7 @@ class ConfigEnvironments {
     );
   }
 }''';
+
+  @override
+  String? get getX5Content => null;
 }

--- a/lib/samples/impl/generate_locales.dart
+++ b/lib/samples/impl/generate_locales.dart
@@ -31,4 +31,7 @@ class Locales {
 \t$_locales
 }
 ''';
+
+  @override
+  String? get getX5Content => null;
 }

--- a/lib/samples/impl/get_app_pages.dart
+++ b/lib/samples/impl/get_app_pages.dart
@@ -23,4 +23,7 @@ class AppPages {
   ];
 }
 ''';
+
+  @override
+  String? get getX5Content => null;
 }

--- a/lib/samples/impl/get_binding.dart
+++ b/lib/samples/impl/get_binding.dart
@@ -42,7 +42,7 @@ class $_bindingName extends Binding {
     return [
       Bind.lazyPut<${_fileName.pascalCase}Controller>(
         () => ${_fileName.pascalCase}Controller(),
-      );
+      ),
     ];
   }
 }

--- a/lib/samples/impl/get_binding.dart
+++ b/lib/samples/impl/get_binding.dart
@@ -31,4 +31,20 @@ class $_bindingName extends Bindings {
   }
 }
 ''';
+
+  @override
+  String? get getX5Content => '''$_import
+import 'package:${PubspecUtils.projectName}/$_controllerDir';
+
+class $_bindingName extends Binding {
+  @override
+  List<Bind> dependencies() {
+    return [
+      Bind.lazyPut<${_fileName.pascalCase}Controller>(
+        () => ${_fileName.pascalCase}Controller(),
+      );
+    ];
+  }
+}
+''';
 }

--- a/lib/samples/impl/get_controller.dart
+++ b/lib/samples/impl/get_controller.dart
@@ -54,4 +54,7 @@ class ${_fileName.pascalCase}Controller extends GetxController {
   void increment() => count.value++;
 }
 ''';
+
+  @override
+  String? get getX5Content => null;
 }

--- a/lib/samples/impl/get_provider.dart
+++ b/lib/samples/impl/get_provider.dart
@@ -60,4 +60,7 @@ if(map is Map<String, dynamic>) return $_namePascal.fromJson(map);
 if(map is List) return map.map((item)=> $_namePascal.fromJson(item)).toList();
 };\n'''
       : '\n';
+
+  @override
+  String? get getX5Content => null;
 }

--- a/lib/samples/impl/get_route.dart
+++ b/lib/samples/impl/get_route.dart
@@ -19,4 +19,7 @@ abstract class _Paths {
 }
 
 ''';
+
+  @override
+  String? get getX5Content => null;
 }

--- a/lib/samples/impl/get_server/pubspec.dart
+++ b/lib/samples/impl/get_server/pubspec.dart
@@ -18,4 +18,7 @@ dependencies:
 dev_dependencies:
 
 ''';
+
+  @override
+  String? get getX5Content => null;
 }

--- a/lib/samples/impl/get_view.dart
+++ b/lib/samples/impl/get_view.dart
@@ -56,4 +56,7 @@ class $_viewName extends $_controllerName {
 
   @override
   String get content => _isServer ? _serverView : _flutterView;
+
+  @override
+  String? get getX5Content => null;
 }

--- a/lib/samples/impl/getx_pattern/get_main.dart
+++ b/lib/samples/impl/getx_pattern/get_main.dart
@@ -32,4 +32,7 @@ void main() {
 
   @override
   String get content => isServer! ? _serverMain : _flutterMain;
+
+  @override
+  String? get getX5Content => null;
 }

--- a/lib/samples/interface/sample_interface.dart
+++ b/lib/samples/interface/sample_interface.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'package:path/path.dart' as path_lib;
 import 'package:pubspec_parse/pubspec_parse.dart';
 
 import '../../functions/create/create_single_file.dart';
@@ -29,9 +28,7 @@ abstract class Sample {
 
   /// check if project using GetX 5
   bool isUsingGetX5() {
-    final pubspecFile = File(
-      path_lib.join(Directory.current.toString(), 'pubspec.yaml'),
-    );
+    final pubspecFile = File('pubspec.yaml');
     final pubSpec = Pubspec.parse(pubspecFile.readAsStringSync());
 
     if(pubSpec.dependencies['get'] == null ) return false;

--- a/lib/samples/interface/sample_interface.dart
+++ b/lib/samples/interface/sample_interface.dart
@@ -1,4 +1,6 @@
 import 'dart:io';
+import 'package:path/path.dart' as path_lib;
+import 'package:pubspec_parse/pubspec_parse.dart';
 
 import '../../functions/create/create_single_file.dart';
 
@@ -20,14 +22,33 @@ abstract class Sample {
   /// by path.
   String get content;
 
+  /// Store the (GetX 5 content) that will be written to the file in a String or
+  /// Future <String> in that variable. It is used to fill the file created
+  /// by path.
+  String? get getX5Content;
+
+  /// check if project using GetX 5
+  bool isUsingGetX5() {
+    final pubspecFile = File(
+      path_lib.join(Directory.current.toString(), 'pubspec.yaml'),
+    );
+    final pubSpec = Pubspec.parse(pubspecFile.readAsStringSync());
+
+    if(pubSpec.dependencies['get'] == null ) return false;
+
+    return pubSpec.dependencies['get'].toString().contains('^5') ||
+        pubSpec.dependencies['get'].toString().contains(': 5');
+  }
+
   Sample(this.path, {this.overwrite = false});
 
   /// This function will create the file in [path] with the
-  /// content of [content].
+  /// content of [content] or [getX5Content] according to he used get version.
   File create({bool skipFormatter = false}) {
     return writeFile(
       path,
-      customContent.isNotEmpty ? customContent : content,
+      customContent.isNotEmpty ? customContent : isUsingGetX5() && getX5Content
+          != null ? getX5Content! : content,
       overwrite: overwrite,
       skipFormatter: skipFormatter,
       useRelativeImport: true,


### PR DESCRIPTION
- Add getX5Content field for the **Sample** class, this will make it easy to add **GetX5** content to each sample **anytime**.
- Edit Sample class to generate **GetX5** content **only if its available on sample and if project is using GetX5** 
- Added GetX5 content for **(bindings)** so now if project is using GetX5 it will write the new bindings shape.